### PR TITLE
Promote web to whereismyjetpack/gitops

### DIFF
--- a/env/fastify-url-shortner/staging/kustomization.yaml
+++ b/env/fastify-url-shortner/staging/kustomization.yaml
@@ -13,3 +13,6 @@ images:
   newTag: 1c77616a1092268608ba6d0523d54ca25bb6e39f
 - name: public.ecr.aws/nginx/nginx
   newTag: 1.27.2
+- name: web
+  newName: ghcr.io/whereismyjetpack/monorepo-web
+  newTag: web-0.0.3


### PR DESCRIPTION
  ---
  GITHUB_EVENT_NAME: push
  GITHUB_JOB: build
  GITHUB_REF_URL: https://github.com/whereismyjetpack/monorepo/tree/refs/heads/main
  GITHUB_REF: refs/heads/main
  GITHUB_REPOSITORY_URL: https://github.com/whereismyjetpack/monorepo
  GITHUB_REPOSITORY: whereismyjetpack/monorepo
  GITHUB_RUN_ID: 12943135763
  GITHUB_RUN_NUMBER: 47
  GITHUB_SHA_URL: https://github.com/whereismyjetpack/monorepo/commit/596f63b84f1686d8af34cad3c0b33e409f85c7ba
  GITHUB_SHA: 596f63b84f1686d8af34cad3c0b33e409f85c7ba
  GITHUB_WORKFLOW_RUN_URL: https://github.com/whereismyjetpack/monorepo/actions/runs/12943135763
  IMAGES: web
  CHARTS:
  OVERLAYS: env/fastify-url-shortner/staging
  MANIFEST_JSON: {"env/fastify-url-shortner/staging":{"images":[{"name":"web","newName":"ghcr.io/whereismyjetpack/monorepo-web","newTag":"web-0.0.3"}]}}
